### PR TITLE
Fix CUDA vector multiply for RTX 5070

### DIFF
--- a/chapter-02/code/vecMul.py
+++ b/chapter-02/code/vecMul.py
@@ -29,7 +29,11 @@ def compile_extension():
         cuda_sources=cuda_source,
         functions=["vector_multiplication"],
         with_cuda=True,
-        # extra_cuda_cflags=["-O2"]
+        extra_cuda_cflags=[
+            "-O2",
+            "-gencode=arch=compute_120,code=sm_120",
+            "-gencode=arch=compute_120,code=compute_120",
+        ],
     )
 
 

--- a/chapter-02/code/vecMulTorchTensor.cu
+++ b/chapter-02/code/vecMulTorchTensor.cu
@@ -25,5 +25,5 @@ torch::Tensor vector_multiplication(torch::Tensor A, torch::Tensor B) {
 
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-    return A;
+    return C;
 }


### PR DESCRIPTION
you can ignore the changes in chapter-02/code/vecMul.py, that's specific to running on my RTX 5070 

But chapter-02/code/vecMulTorchTensor.cu I made a simple correction to return C rather than A

Thanks for this repo btw, I'm currently making my way through the PMPP book and this is extremely helpful!